### PR TITLE
feat: 제목 변경 기능 구현

### DIFF
--- a/src/docs/asciidoc/api/room.adoc
+++ b/src/docs/asciidoc/api/room.adoc
@@ -160,3 +160,47 @@ include::{snippets}/enter-full-room-fail/http-request.adoc[]
 include::{snippets}/enter-full-room-fail/http-response.adoc[]
 include::{snippets}/enter-full-room-fail/response-fields.adoc[]
 
+{nbsp}
+
+[[change-room-title-success]]
+=== 방 제목 변경 성공
+
+==== HTTP Request
+
+include::{snippets}/change-room-title-success/http-request.adoc[]
+include::{snippets}/change-room-title-success/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/change-room-title-success/http-response.adoc[]
+include::{snippets}/change-room-title-success/response-fields.adoc[]
+
+{nbsp}
+
+[[change-room-title-form-fail]]
+=== 방 제목 변경 실패: 요청한 데이터 형식 오류
+
+==== HTTP Request
+
+include::{snippets}/change-room-title-form-fail/http-request.adoc[]
+include::{snippets}/change-room-title-form-fail/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/change-room-title-form-fail/http-response.adoc[]
+include::{snippets}/change-room-title-form-fail/response-fields.adoc[]
+
+{nbsp}
+
+[[change-room-title-not-host-fail]]
+=== 방 제목 변경 실패: 호스트가 아닌 유저는 방 제목 변경 불가
+
+==== HTTP Request
+
+include::{snippets}/change-room-title-not-host-fail/http-request.adoc[]
+include::{snippets}/change-room-title-not-host-fail/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/change-room-title-not-host-fail/http-response.adoc[]
+include::{snippets}/change-room-title-not-host-fail/response-fields.adoc[]

--- a/src/main/java/site/youtogether/exception/ErrorType.java
+++ b/src/main/java/site/youtogether/exception/ErrorType.java
@@ -18,6 +18,7 @@ public enum ErrorType {
 	HIGHER_OR_EQUAL_ROLE_CHANGE(HttpStatus.FORBIDDEN, "자신보다 높거나 같은 역할로 변경할 수 없습니다"),
 	NOT_MANAGEABLE(HttpStatus.FORBIDDEN, "다른 사람의 역할을 변경할 수 없습니다"),
 	CHAT_MESSAGE_SEND_DENIED(HttpStatus.FORBIDDEN, "채팅 메시지를 보낼 권한이 없습니다"),
+	ROOM_TITLE_CHANGE_DENIED(HttpStatus.FORBIDDEN, "방 제목을 변경할 권한이 없습니다"),
 
 	// Room
 	ROOM_NO_EXISTENCE(HttpStatus.NOT_FOUND, "방이 없습니다"),

--- a/src/main/java/site/youtogether/exception/user/ChangeRoomTitleDeniedException.java
+++ b/src/main/java/site/youtogether/exception/user/ChangeRoomTitleDeniedException.java
@@ -1,0 +1,12 @@
+package site.youtogether.exception.user;
+
+import site.youtogether.exception.CustomException;
+import site.youtogether.exception.ErrorType;
+
+public class ChangeRoomTitleDeniedException extends CustomException {
+
+	public ChangeRoomTitleDeniedException() {
+		super(ErrorType.ROOM_TITLE_CHANGE_DENIED);
+	}
+
+}

--- a/src/main/java/site/youtogether/message/RoomTitleMessage.java
+++ b/src/main/java/site/youtogether/message/RoomTitleMessage.java
@@ -1,0 +1,19 @@
+package site.youtogether.message;
+
+import lombok.Getter;
+import site.youtogether.room.Room;
+
+@Getter
+public class RoomTitleMessage {
+
+	private final MessageType messageType = MessageType.ROOM_TITLE;
+
+	private final String roomCode;
+	private final String updatedTitle;
+
+	public RoomTitleMessage(Room room) {
+		this.roomCode = room.getCode();
+		this.updatedTitle = room.getTitle();
+	}
+
+}

--- a/src/main/java/site/youtogether/message/application/RedisSubscriber.java
+++ b/src/main/java/site/youtogether/message/application/RedisSubscriber.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import site.youtogether.exception.room.RoomNoExistenceException;
 import site.youtogether.message.ChatMessage;
 import site.youtogether.message.ParticipantsInfoMessage;
+import site.youtogether.message.RoomTitleMessage;
 import site.youtogether.room.Room;
 import site.youtogether.room.infrastructure.RoomStorage;
 import site.youtogether.user.dto.UserInfo;
@@ -43,6 +44,14 @@ public class RedisSubscriber {
 
 		ParticipantsInfoMessage participantsInfoMessage = new ParticipantsInfoMessage(participants);
 		messagingTemplate.convertAndSend("/sub/messages/rooms/" + roomCode, participantsInfoMessage);
+	}
+
+	public void sendRoomTitle(String roomCode) {
+		Room room = roomStorage.findById(roomCode)
+			.orElseThrow(RoomNoExistenceException::new);
+
+		RoomTitleMessage roomTitleMessage = new RoomTitleMessage(room);
+		messagingTemplate.convertAndSend("/sub/messages/rooms/" + roomCode, roomTitleMessage);
 	}
 
 }

--- a/src/main/java/site/youtogether/room/Room.java
+++ b/src/main/java/site/youtogether/room/Room.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.youtogether.exception.room.PasswordNotMatchException;
 import site.youtogether.exception.room.RoomCapacityExceededException;
+import site.youtogether.exception.user.ChangeRoomTitleDeniedException;
 import site.youtogether.exception.user.HigherOrEqualRoleChangeException;
 import site.youtogether.exception.user.HigherOrEqualRoleUserChangeException;
 import site.youtogether.exception.user.NotManageableUserException;
@@ -111,6 +112,14 @@ public class Room {
 
 		changedUser.changeRole(changeRole);
 		return changedUser;
+	}
+
+	public void changeRoomTitle(Long userId, String updateTitle) {
+		User user = findParticipantBy(userId);
+		if (!user.isHost()) {
+			throw new ChangeRoomTitleDeniedException();
+		}
+		title = updateTitle;
 	}
 
 }

--- a/src/main/java/site/youtogether/room/dto/RoomTitleChangeForm.java
+++ b/src/main/java/site/youtogether/room/dto/RoomTitleChangeForm.java
@@ -1,0 +1,20 @@
+package site.youtogether.room.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RoomTitleChangeForm {
+
+	@NotNull
+	private final String roomCode;
+
+	@NotBlank(message = "공백이 아닌 문자를 1개 이상 입력해 주세요")
+	@Size(min = 1, max = 30, message = "제목은 {min}자 이상 {max}자 이하로 입력해 주세요")
+	private final String updateTitle;
+
+}

--- a/src/main/java/site/youtogether/room/dto/UpdatedRoomTitle.java
+++ b/src/main/java/site/youtogether/room/dto/UpdatedRoomTitle.java
@@ -1,0 +1,19 @@
+package site.youtogether.room.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.youtogether.room.Room;
+
+@RequiredArgsConstructor
+@Getter
+public class UpdatedRoomTitle {
+
+	private final String roomCode;
+	private final String updatedRoomTitle;
+
+	public UpdatedRoomTitle(Room room) {
+		this.roomCode = room.getCode();
+		this.updatedRoomTitle = room.getTitle();
+	}
+
+}

--- a/src/main/java/site/youtogether/room/presentation/RoomController.java
+++ b/src/main/java/site/youtogether/room/presentation/RoomController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,9 +27,12 @@ import site.youtogether.room.dto.PasswordInput;
 import site.youtogether.room.dto.RoomDetail;
 import site.youtogether.room.dto.RoomList;
 import site.youtogether.room.dto.RoomSettings;
+import site.youtogether.room.dto.RoomTitleChangeForm;
+import site.youtogether.room.dto.UpdatedRoomTitle;
 import site.youtogether.util.RandomUtil;
 import site.youtogether.util.api.ApiResponse;
 import site.youtogether.util.api.ResponseResult;
+import site.youtogether.util.resolver.UserTracking;
 
 @RestController
 @RequiredArgsConstructor
@@ -67,6 +71,14 @@ public class RoomController {
 		response.setHeader(HttpHeaders.SET_COOKIE, sessionCookie.toString());
 		return ResponseEntity.ok(
 			ApiResponse.ok(ResponseResult.ROOM_ENTER_SUCCESS, roomDetail));
+	}
+
+	@PatchMapping("/rooms/title")
+	public ResponseEntity<ApiResponse<UpdatedRoomTitle>> changeRoomTitle(@UserTracking Long userId, @Valid @RequestBody RoomTitleChangeForm form) {
+		UpdatedRoomTitle updatedRoomTitle = roomService.changeRoomTitle(userId, form.getRoomCode(), form.getUpdateTitle());
+
+		return ResponseEntity.ok(
+			ApiResponse.ok(ResponseResult.ROOM_TITLE_CHANGE_SUCCESS, updatedRoomTitle));
 	}
 
 	private ResponseCookie generateSessionCookie() {

--- a/src/main/java/site/youtogether/user/User.java
+++ b/src/main/java/site/youtogether/user/User.java
@@ -41,4 +41,8 @@ public class User {
 		return role == Role.VIEWER;
 	}
 
+	public boolean isHost() {
+		return role == Role.HOST;
+	}
+
 }

--- a/src/main/java/site/youtogether/user/presentation/UserController.java
+++ b/src/main/java/site/youtogether/user/presentation/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
 		return ResponseEntity.ok(ApiResponse.ok(ResponseResult.USER_NICKNAME_UPDATE_SUCCESS, userInfo));
 	}
 
-	@PatchMapping("/users/change-role")
+	@PatchMapping("/users/role")
 	public ResponseEntity<ApiResponse<UserInfo>> changeUserRole(@UserTracking Long userId, @Valid @RequestBody UserRoleChangeForm form) {
 		UserInfo changedUserInfo = userService.changeUserRole(userId, form);
 

--- a/src/main/java/site/youtogether/util/api/ResponseResult.java
+++ b/src/main/java/site/youtogether/util/api/ResponseResult.java
@@ -12,6 +12,7 @@ public enum ResponseResult {
 	ROOM_CREATION_SUCCESS("방 생성에 성공했습니다"),
 	ROOM_ENTER_SUCCESS("방 입장에 성공했습니다"),
 	ROOM_LIST_FETCH_SUCCESS("방 목록 조회에 성공했습니다"),
+	ROOM_TITLE_CHANGE_SUCCESS("방 제목 변경에 성공했습니다"),
 
 	// User
 	USER_NICKNAME_UPDATE_SUCCESS("유저 닉네임 변경에 성공했습니다"),

--- a/src/test/java/site/youtogether/room/RoomTest.java
+++ b/src/test/java/site/youtogether/room/RoomTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import site.youtogether.exception.user.ChangeRoomTitleDeniedException;
 import site.youtogether.exception.user.HigherOrEqualRoleChangeException;
 import site.youtogether.exception.user.HigherOrEqualRoleUserChangeException;
 import site.youtogether.exception.user.NotManageableUserException;
@@ -87,6 +88,37 @@ class RoomTest {
 		// when // then
 		assertThatThrownBy(() -> room.changeParticipantRole(HOST_ID, HOST_ID, Role.GUEST))
 			.isInstanceOf(SelfRoleChangeException.class);
+	}
+
+	@Test
+	@DisplayName("호스트는 방 제목을 변경할 수 있다")
+	void changeRoomTitle() throws Exception {
+		// given
+		Room room = createRoom(LocalDateTime.of(2024, 4, 14, 10, 37, 0));
+		String originTitle = room.getTitle();
+		String updateTitle = "연츠비의 방";
+
+		// when
+		room.changeRoomTitle(HOST_ID, updateTitle);
+
+		// then
+		assertThat(room.getTitle()).isNotEqualTo(originTitle);
+		assertThat(room.getTitle()).isEqualTo(updateTitle);
+	}
+
+	@Test
+	@DisplayName("호스트가 아닌 유저는 방 제목을 변경할 수 없다")
+	void changeRoomTitleFail() throws Exception {
+		// given
+		Room room = createRoom(LocalDateTime.of(2024, 4, 14, 10, 37, 0));
+		User user = createUser(2L, "연츠비", Role.MANAGER);
+		room.enterParticipant(user, null);
+
+		String updateTitle = "연츠비의 방";
+
+		// when // then
+		assertThatThrownBy(() -> room.changeRoomTitle(user.getUserId(), updateTitle))
+			.isInstanceOf(ChangeRoomTitleDeniedException.class);
 	}
 
 	private Room createRoom(LocalDateTime createTime) {

--- a/src/test/java/site/youtogether/room/application/RoomServiceTest.java
+++ b/src/test/java/site/youtogether/room/application/RoomServiceTest.java
@@ -29,6 +29,8 @@ import site.youtogether.user.infrastructure.UserTrackingStorage;
 
 class RoomServiceTest extends IntegrationTestSupport {
 
+	private static final Long HOST_ID = 100L;
+
 	@Autowired
 	private RoomService roomService;
 
@@ -201,9 +203,27 @@ class RoomServiceTest extends IntegrationTestSupport {
 		assertThat(savedRoom.getParticipants()).doesNotContainKey(user.getUserId());
 	}
 
+	@Test
+	@DisplayName("방 제목을 바꾼다")
+	void changeRoom() throws Exception {
+		// given
+		Room room = createRoom(LocalDateTime.of(2024, 4, 10, 11, 37, 0), "황똥땡의 방");
+		roomStorage.save(room);
+
+		String updateTitle = "연똥땡의 방";
+
+		// when
+		roomService.changeRoomTitle(HOST_ID, room.getCode(), updateTitle);
+
+		// then
+		Room savedRoom = roomStorage.findById(room.getCode()).get();
+		assertThat(savedRoom.getTitle()).isEqualTo(updateTitle);
+	}
+
 	private Room createRoom(LocalDateTime createTime, String title) {
 		User user = User.builder()
-			.userId(100L)
+			.userId(HOST_ID)
+			.role(Role.HOST)
 			.build();
 
 		Room room = Room.builder()
@@ -220,7 +240,8 @@ class RoomServiceTest extends IntegrationTestSupport {
 
 	private Room createRoom(LocalDateTime createTime, String title, int capacity) {
 		User user = User.builder()
-			.userId(100L)
+			.userId(HOST_ID)
+			.role(Role.HOST)
 			.build();
 
 		Room room = Room.builder()
@@ -237,7 +258,8 @@ class RoomServiceTest extends IntegrationTestSupport {
 
 	private Room createPasswordRoom(LocalDateTime createTime, String title, String password) {
 		User user = User.builder()
-			.userId(100L)
+			.role(Role.HOST)
+			.userId(HOST_ID)
 			.build();
 
 		Room room = Room.builder()

--- a/src/test/java/site/youtogether/user/presentation/UserControllerTest.java
+++ b/src/test/java/site/youtogether/user/presentation/UserControllerTest.java
@@ -144,7 +144,7 @@ class UserControllerTest extends RestDocsSupport {
 			.willReturn(userInfo);
 
 		// when // then
-		mockMvc.perform(patch("/users/change-role")
+		mockMvc.perform(patch("/users/role")
 				.content(objectMapper.writeValueAsString(userRoleChangeForm))
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(sessionCookie))
@@ -191,7 +191,7 @@ class UserControllerTest extends RestDocsSupport {
 			.willThrow(new SelfRoleChangeException());
 
 		// when // then
-		mockMvc.perform(patch("/users/change-role")
+		mockMvc.perform(patch("/users/role")
 				.content(objectMapper.writeValueAsString(userRoleChangeForm))
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(sessionCookie))
@@ -239,7 +239,7 @@ class UserControllerTest extends RestDocsSupport {
 			.willThrow(new HigherOrEqualRoleUserChangeException());
 
 		// when // then
-		mockMvc.perform(patch("/users/change-role")
+		mockMvc.perform(patch("/users/role")
 				.content(objectMapper.writeValueAsString(userRoleChangeForm))
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(sessionCookie))
@@ -287,7 +287,7 @@ class UserControllerTest extends RestDocsSupport {
 			.willThrow(new HigherOrEqualRoleChangeException());
 
 		// when // then
-		mockMvc.perform(patch("/users/change-role")
+		mockMvc.perform(patch("/users/role")
 				.content(objectMapper.writeValueAsString(userRoleChangeForm))
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(sessionCookie))
@@ -335,7 +335,7 @@ class UserControllerTest extends RestDocsSupport {
 			.willThrow(new NotManageableUserException());
 
 		// when // then
-		mockMvc.perform(patch("/users/change-role")
+		mockMvc.perform(patch("/users/role")
 				.content(objectMapper.writeValueAsString(userRoleChangeForm))
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(sessionCookie))
@@ -347,7 +347,7 @@ class UserControllerTest extends RestDocsSupport {
 			.andExpect(jsonPath("$.data").isArray())
 			.andExpect(jsonPath("$.data[0].type").value(NotManageableUserException.class.getSimpleName()))
 			.andExpect(jsonPath("$.data[0].message").value(ErrorType.NOT_MANAGEABLE.getMessage()))
-			.andDo(document("not-manageable-change-role-fail",
+			.andDo(document("not-manageable-role-fail",
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				requestFields(


### PR DESCRIPTION
- 방 제목 변경 기능을 구현한다.
- 이름이 변경되면, 해당하는 방에 변경된 방 제목 메시지를 보낸다.