### PR TITLE
feat: 유저 히스토리 길이 제한

### DIFF
--- a/src/main/java/site/youtogether/room/application/RoomService.java
+++ b/src/main/java/site/youtogether/room/application/RoomService.java
@@ -6,14 +6,13 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import site.youtogether.exception.room.RoomNoExistenceException;
 import site.youtogether.exception.user.UserNoExistenceException;
 import site.youtogether.message.AlarmMessage;
-import site.youtogether.message.ChatHistory;
 import site.youtogether.message.application.MessageService;
 import site.youtogether.playlist.Playlist;
 import site.youtogether.playlist.infrastructure.PlaylistStorage;
@@ -37,7 +36,7 @@ public class RoomService {
 	private final PlaylistStorage playlistStorage;
 	private final UserStorage userStorage;
 	private final MessageService messageService;
-	private final RedisTemplate<String, ChatHistory> chatRedisTemplate;
+	private final StringRedisTemplate redisTemplate;
 
 	public NewRoom create(Long userId, RoomSettings roomSettings, LocalDateTime now) {
 		String roomCode = RandomUtil.generateRandomCode(ROOM_CODE_LENGTH);

--- a/src/main/java/site/youtogether/util/AppConstants.java
+++ b/src/main/java/site/youtogether/util/AppConstants.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public final class AppConstants {
 
 	public static final int ROOM_CODE_LENGTH = 10;
+	public static final int USER_HISTORY_LENGTH = 10;
 	public static final String STOMP_ENDPOINT = "/stomp";
 	public static final String USER_ID = "userId";
 	public static final String ROOM_CODE = "roomCode";

--- a/src/test/java/site/youtogether/user/UserTest.java
+++ b/src/test/java/site/youtogether/user/UserTest.java
@@ -167,4 +167,67 @@ class UserTest {
 		assertThat(user.getNickname()).isEqualTo(updateNickname);
 	}
 
+	@Test
+	@DisplayName("방 참여 기록은 최대 10개까지 저장된다")
+	void historyLength() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.nickname("황똥땡")
+			.build();
+
+		// when
+		for (int i = 0; i < 10; i++) {
+			user.enterRoom("roomCode" + i);
+		}
+
+		// then
+		assertThat(user.getHistory().size()).isEqualTo(10);
+	}
+
+	@Test
+	@DisplayName("방 참여 기록이 10개를 넘어가면, 가장 오래전에 방문한 방의 기록부터 제거한다")
+	void historyLimitExceed() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.nickname("황똥땡")
+			.build();
+
+		String firstRoomCode = "firstRoomCode";
+		user.enterRoom(firstRoomCode);
+
+		// when
+		for (int i = 0; i < 10; i++) {
+			user.enterRoom("roomCode" + i);
+		}
+
+		// then
+		assertThat(user.getHistory().size()).isEqualTo(10);
+		assertThat(user.getHistory()).doesNotContainKey(firstRoomCode);
+	}
+
+	@Test
+	@DisplayName("방을 재입장 한 경우, 방문 순서가 갱신된다")
+	void historyUpdate() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.nickname("황똥땡")
+			.build();
+
+		String firstRoomCode = "firstRoomCode";
+		user.enterRoom(firstRoomCode);
+
+		// when
+		for (int i = 0; i < 3; i++) {
+			user.enterRoom("roomCode" + i);
+		}
+		user.enterRoom(firstRoomCode);
+
+		// then
+		assertThat(user.getHistory().size()).isEqualTo(4);
+		assertThat(user.getRoomCodeQueue()).containsExactly("roomCode0", "roomCode1", "roomCode2", "firstRoomCode");
+	}
+
 }


### PR DESCRIPTION
- 유저 히스토리의 길이를 10으로 제한합니다.
- User 도메인 내부에 roomCodeQueue 필드를 추가하여 LRU 방식으로 길이를 제한합니다.
