### PR TITLE
refactor: 유저가 애플리케이션 내에서 고유한 닉네임을 갖도록 구조 변경

### DIFF
--- a/src/docs/asciidoc/api/user.adoc
+++ b/src/docs/asciidoc/api/user.adoc
@@ -31,6 +31,21 @@ include::{snippets}/change-nickname-fail/response-fields.adoc[]
 
 {nbsp}
 
+[[change-nickname-fail-duplicate]]
+=== 닉네임 변경 실패: 중복된 닉네임입니다
+
+==== HTTP Request
+
+include::{snippets}/change-nickname-fail-duplicate/http-request.adoc[]
+include::{snippets}/change-nickname-fail-duplicate/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/change-nickname-fail-duplicate/http-response.adoc[]
+include::{snippets}/change-nickname-fail-duplicate/response-fields.adoc[]
+
+{nbsp}
+
 [[change-role-success]]
 === 다른 유저의 역할 변경 성공
 
@@ -104,4 +119,3 @@ include::{snippets}/change-role-fail-not-manageable-user/request-fields.adoc[]
 include::{snippets}/change-role-fail-not-manageable-user/http-response.adoc[]
 include::{snippets}/change-role-fail-not-manageable-user/response-fields.adoc[]
 
-{nbsp}

--- a/src/main/java/site/youtogether/config/RedisConfig.java
+++ b/src/main/java/site/youtogether/config/RedisConfig.java
@@ -42,6 +42,14 @@ public class RedisConfig {
 	}
 
 	@Bean
+	public DefaultRedisScript<Boolean> updateUniqueNicknameScript() {
+		DefaultRedisScript<Boolean> redisScript = new DefaultRedisScript<>();
+		redisScript.setScriptSource(new ResourceScriptSource(new ClassPathResource("script/update-unique-nickname.lua")));
+		redisScript.setResultType(Boolean.class);
+		return redisScript;
+	}
+
+	@Bean
 	public RedisTemplate<String, ChatHistory> redisTemplate() {
 		RedisTemplate<String, ChatHistory> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/site/youtogether/exception/ErrorType.java
+++ b/src/main/java/site/youtogether/exception/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
 	ROOM_TITLE_CHANGE_DENIED(HttpStatus.FORBIDDEN, "방 제목을 변경할 권한이 없습니다"),
 	USERS_IN_DIFFERENT_ROOM(HttpStatus.BAD_REQUEST, "해당 방에 두 유저가 존재하지 않습니다"),
 	VIDEO_EDIT_DENIED(HttpStatus.FORBIDDEN, "영상 관련 작업을 할 권한이 없습니다"),
+	USER_NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다"),
 
 	// Room
 	ROOM_NO_EXISTENCE(HttpStatus.NOT_FOUND, "방이 없습니다"),

--- a/src/main/java/site/youtogether/exception/user/UserNicknameDuplicateException.java
+++ b/src/main/java/site/youtogether/exception/user/UserNicknameDuplicateException.java
@@ -1,0 +1,12 @@
+package site.youtogether.exception.user;
+
+import site.youtogether.exception.CustomException;
+import site.youtogether.exception.ErrorType;
+
+public class UserNicknameDuplicateException extends CustomException {
+
+	public UserNicknameDuplicateException() {
+		super(ErrorType.USER_NICKNAME_DUPLICATE);
+	}
+
+}

--- a/src/main/java/site/youtogether/user/application/UserService.java
+++ b/src/main/java/site/youtogether/user/application/UserService.java
@@ -9,6 +9,7 @@ import site.youtogether.message.application.MessageService;
 import site.youtogether.room.Participant;
 import site.youtogether.user.User;
 import site.youtogether.user.dto.UserRoleChangeForm;
+import site.youtogether.user.infrastructure.UniqueNicknameStorage;
 import site.youtogether.user.infrastructure.UserStorage;
 import site.youtogether.util.RandomUtil;
 import site.youtogether.util.aop.UserSynchronize;
@@ -19,10 +20,13 @@ public class UserService {
 
 	private final UserStorage userStorage;
 	private final MessageService messageService;
+	private final UniqueNicknameStorage uniqueNicknameStorage;
 
 	public Participant changeUserNickname(Long userId, String newNickname) {
 		User user = userStorage.findById(userId)
 			.orElseThrow(UserNoExistenceException::new);
+
+		uniqueNicknameStorage.update(user.getNickname(), newNickname);
 		user.changeNickname(newNickname);
 		userStorage.save(user);
 

--- a/src/main/java/site/youtogether/user/infrastructure/UniqueNicknameStorage.java
+++ b/src/main/java/site/youtogether/user/infrastructure/UniqueNicknameStorage.java
@@ -1,0 +1,41 @@
+package site.youtogether.user.infrastructure;
+
+import static site.youtogether.util.AppConstants.*;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import site.youtogether.exception.user.UserNicknameDuplicateException;
+
+@Repository
+@RequiredArgsConstructor
+public class UniqueNicknameStorage {
+
+	private final StringRedisTemplate redisTemplate;
+	private final RedisScript<Boolean> updateUniqueNicknameScript;
+
+	public boolean exist(String nickname) {
+		return redisTemplate.opsForSet().isMember(USER_NICKNAME_SET, nickname);
+	}
+
+	public void save(String nickname) {
+		redisTemplate.opsForSet().add(USER_NICKNAME_SET, nickname);
+	}
+
+	public void update(String oldNickname, String newNickname) {
+		Boolean updateResult = redisTemplate.execute(updateUniqueNicknameScript, List.of(USER_NICKNAME_SET), oldNickname, newNickname);
+
+		if (!updateResult) {
+			throw new UserNicknameDuplicateException();
+		}
+	}
+
+	public void delete() {
+		redisTemplate.delete(USER_NICKNAME_SET);
+	}
+
+}

--- a/src/main/java/site/youtogether/util/AppConstants.java
+++ b/src/main/java/site/youtogether/util/AppConstants.java
@@ -12,6 +12,7 @@ public final class AppConstants {
 	public static final String USER_ID = "userId";
 	public static final String ROOM_CODE = "roomCode";
 	public static final String CHAT_PREFIX = "chat:";
+	public static final String USER_NICKNAME_SET = "userNicknames";
 	public static final String SUBSCRIBE_PATH = "/sub/messages/rooms/";
 
 }

--- a/src/main/java/site/youtogether/util/DataCleaner.java
+++ b/src/main/java/site/youtogether/util/DataCleaner.java
@@ -1,5 +1,7 @@
 package site.youtogether.util;
 
+import static site.youtogether.util.AppConstants.*;
+
 import java.util.List;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,7 +21,7 @@ public class DataCleaner {
 	@Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
 	public void clean() {
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 	}
 
 }

--- a/src/main/java/site/youtogether/util/RandomUtil.java
+++ b/src/main/java/site/youtogether/util/RandomUtil.java
@@ -49,9 +49,10 @@ public final class RandomUtil {
 			"GoldenGlider", "CrimsonFalcon", "EchoingWhisper", "EmberPhoenix", "RadiantRebel"
 		);
 
-		int randomIndex = ThreadLocalRandom.current().nextInt(samples.size());
+		int prefixIndex = ThreadLocalRandom.current().nextInt(samples.size());
+		int suffixNumber = ThreadLocalRandom.current().nextInt(1000);
 
-		return samples.get(randomIndex);
+		return samples.get(prefixIndex) + suffixNumber;
 	}
 
 }

--- a/src/main/resources/script/batch-removal-operation.lua
+++ b/src/main/resources/script/batch-removal-operation.lua
@@ -1,6 +1,6 @@
 local roomIndex = KEYS[1]
 local userIndex = KEYS[2]
-local playlistIndex = KEYS[3]
+local uniqueNicknameSet = KEYS[3]
 
 local eraseRoomList = redis.call("FT.SEARCH", roomIndex, "@activate:{false}", "LIMIT", 0, 10000, "NOCONTENT")
 for i = 2, #eraseRoomList do
@@ -14,17 +14,16 @@ for i = 2, #inactiveRoomList do
     redis.call("JSON.SET", inactiveRoomList[i], "$.activate", "false")
 end
 
-local eraseUserList = redis.call("FT.SEARCH", userIndex, "@activate:{false}", "LIMIT", 0, 10000, "NOCONTENT")
-for i = 2, #eraseUserList do
-    redis.call("DEL", eraseUserList[i])
-end
-
 local userList = redis.call("KEYS", "user:*")
 for _, key in ipairs(userList) do
     local jsonData = redis.call("JSON.GET", key)
     local user = cjson.decode(jsonData)
-    if user.currentRoomCode == nil then
+    if user.activate == false then
+        redis.call("DEL", key)
+        redis.call("SREM", uniqueNicknameSet, user.nickname)
+    elseif user.currentRoomCode == nil then
         redis.call("JSON.SET", key, "$.activate", "false")
     end
 end
+
 

--- a/src/main/resources/script/update-unique-nickname.lua
+++ b/src/main/resources/script/update-unique-nickname.lua
@@ -1,0 +1,13 @@
+local uniqueNicknameSet = KEYS[1]
+local oldNickname = ARGV[1]
+local newNickname = ARGV[2]
+
+local exists = redis.call('sismember', uniqueNicknameSet, newNickname)
+
+if exists == 1 then
+    return false
+else
+    redis.call('srem', uniqueNicknameSet, oldNickname)
+    redis.call('sadd', uniqueNicknameSet, newNickname)
+    return true
+end

--- a/src/test/java/site/youtogether/RestDocsSupport.java
+++ b/src/test/java/site/youtogether/RestDocsSupport.java
@@ -17,6 +17,7 @@ import site.youtogether.playlist.presentation.PlaylistController;
 import site.youtogether.room.application.RoomService;
 import site.youtogether.room.presentation.RoomController;
 import site.youtogether.user.application.UserService;
+import site.youtogether.user.infrastructure.UniqueNicknameStorage;
 import site.youtogether.user.infrastructure.UserStorage;
 import site.youtogether.user.presentation.UserController;
 
@@ -52,5 +53,8 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected PlaylistService playlistService;
+
+	@MockBean
+	protected UniqueNicknameStorage uniqueNicknameStorage;
 
 }

--- a/src/test/java/site/youtogether/util/DataCleanerTest.java
+++ b/src/test/java/site/youtogether/util/DataCleanerTest.java
@@ -19,6 +19,7 @@ import site.youtogether.playlist.infrastructure.PlaylistStorage;
 import site.youtogether.room.Room;
 import site.youtogether.room.infrastructure.RoomStorage;
 import site.youtogether.user.User;
+import site.youtogether.user.infrastructure.UniqueNicknameStorage;
 import site.youtogether.user.infrastructure.UserStorage;
 
 class DataCleanerTest extends IntegrationTestSupport {
@@ -33,6 +34,9 @@ class DataCleanerTest extends IntegrationTestSupport {
 	private PlaylistStorage playlistStorage;
 
 	@Autowired
+	private UniqueNicknameStorage uniqueNicknameStorage;
+
+	@Autowired
 	private StringRedisTemplate redisTemplate;
 
 	@Autowired
@@ -43,6 +47,7 @@ class DataCleanerTest extends IntegrationTestSupport {
 		userStorage.deleteAll();
 		roomStorage.deleteAll();
 		playlistStorage.deleteAll();
+		uniqueNicknameStorage.delete();
 	}
 
 	@Test
@@ -62,7 +67,7 @@ class DataCleanerTest extends IntegrationTestSupport {
 
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
 		Room result = roomStorage.findById(room.getCode()).get();
@@ -92,7 +97,7 @@ class DataCleanerTest extends IntegrationTestSupport {
 
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
 		assertThat(roomStorage.existsById(room.getCode())).isFalse();
@@ -122,7 +127,7 @@ class DataCleanerTest extends IntegrationTestSupport {
 
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
 		Room result = roomStorage.findById(room.getCode()).get();
@@ -143,12 +148,14 @@ class DataCleanerTest extends IntegrationTestSupport {
 			.build();
 
 		userStorage.save(user);
+		uniqueNicknameStorage.save(user.getNickname());
 
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
+		assertThat(uniqueNicknameStorage.exist(user.getNickname())).isTrue();
 		User result = userStorage.findById(user.getId()).get();
 
 		assertThat(result.isActivate()).isFalse();
@@ -165,12 +172,14 @@ class DataCleanerTest extends IntegrationTestSupport {
 			.build();
 
 		userStorage.save(user);
+		uniqueNicknameStorage.save(user.getNickname());
 
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
+		assertThat(uniqueNicknameStorage.exist(user.getNickname())).isFalse();
 		assertThat(userStorage.existsById(user.getId())).isFalse();
 	}
 
@@ -185,14 +194,16 @@ class DataCleanerTest extends IntegrationTestSupport {
 			.build();
 
 		userStorage.save(user);
-
+		uniqueNicknameStorage.save(user.getNickname());
+		
 		// when
 		redisTemplate.execute(batchRemoveScript,
-			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", "site.youtogether.playlist.PlaylistIdx"));
+			List.of("site.youtogether.room.RoomIdx", "site.youtogether.user.UserIdx", USER_NICKNAME_SET));
 
 		// then
 		User result = userStorage.findById(user.getId()).get();
 
+		assertThat(uniqueNicknameStorage.exist(user.getNickname())).isTrue();
 		assertThat(result.isActivate()).isTrue();
 	}
 


### PR DESCRIPTION
- 유저의 닉네임 set 을 관리하는 UniqueNicknameStorage 클래스를 만들었습니다.
- 동시성 처리를 한다면 synchronize 블럭을 사용해야 하는데, 이보다는 lua script 로 update 를 원자적으로 처리하도록 하고, update 실패시 예외를 던지도록 했습니다.
- DataCleaner 에서도 지워지는 유저의 닉네임은 닉네임 set에서 제거하도록 lua script 수정하였습니다.
- 유저의 닉네임 생성 방법은 `20개의 랜덤 닉네임 + 0~999 까지의 랜덤 숫자` 로 만들어집니다.
  - 만약 현재 존재하는 초기 닉네임이 주어진다면 다시 생성합니다.